### PR TITLE
Support for hardware scan button (for built-in scanners) + small enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Wait duration (ms) after keypress event to check if scanning is finished
 Default: 30  
 Average time (ms) between 2 chars. Used to do difference between keyboard typing and scanning
 ###minLength
-Default: :6  
+Default: 6  
 Minimum length for a scanning
 ###endChar
 Default: [9,13]  
 Chars to remove and means end of scanning
-###startChar:
+###startChar
 Default: []  
 Chars to remove and means start of scanning
 ###ignoreIfFocusOn

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Callback after detection of a unsuccessful scanning (scanned string in parameter
 Default: false  
 Callback after receive a char (original keypress event in parameter)
 ###onScanButtonLongPressed
-Default: false
+Default: false  
 Callback after detection of a successfull scan while the scan button was pressed and held down. This can only be used if the scan button behaves as a key itself (see scanButtonKeyCode). This long press event can be used to add a secondary action. For example, if the primary action is to count some items with barcodes (e.g. products at goods-in), it is comes very handy if a number pad pops up on the screen when the scan button is held. Large number can then be easily typed it instead of scanning fifty times in a row. 
+###timeBeforeScanTest
 Default: 100  
 Wait duration (ms) after keypress event to check if scanning is finished
 ###avgTimeByChar
@@ -47,16 +48,16 @@ Minimum length for a scanning
 Default: [9,13]  
 Chars to remove and means end of scanning
 ###startChar:
-Default: []
+Default: []  
 Chars to remove and means start of scanning
 ###ignoreIfFocusOn
-Default: 'input'
+Default: 'input'  
 Ignore scans if the currently focued element matches this selector. This is usefull to let the focused control handle the input by itself. By default, scanner detection is disabled if an input is focused when the scan occurs. The scanned string will be inserted in the input in this case.  For example, if your default action is searching in a list of products for the scanned SKU, you might also have a form to create a new product with an input field for the SKU. If the user sets focus to this field, the scanned code will just be inserted into it and not used for searchig.
 ###scanButtonKeyCode
-Default: 0
+Default: 0  
 Key code of the scanner hardware button (if the scanner button a acts as a key itself). Knowing this key code is important, becaus it is not part oft the scanned code and must be ignored. On the other hand, knowing it can be usefull: pressing the button multiple times fast normally results just in one scan, but you still could count the number of times pressed, allowing the user to input quantities this way (typical use case would be counting product at goods-in). 
 ###scanButtonLongPressThreshold
-Default: 3
+Default: 3  
 You can let the user perform some special action by pressing and holding the scan button. In this case the button will issue multiple keydown events. This parameter sets, how many sequential events should be interpreted as holding the button down.  
 ###stopPropagation
 Default: false  

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ To initialize the detection, 2 ways:
 To simulate a scanning after initialisation:
 
     $(selector).scannerDetection('scanned string');
+	
+To disable the detection (deinitialize):
+
+    $(selector).scannerDetection(false);
 
 
 Options
@@ -28,7 +32,9 @@ Callback after detection of a unsuccessful scanning (scanned string in parameter
 ###onReceive
 Default: false  
 Callback after receive a char (original keypress event in parameter)
-###timeBeforeScanTest
+###onScanButtonLongPressed
+Default: false
+Callback after detection of a successfull scan while the scan button was pressed and held down. This can only be used if the scan button behaves as a key itself (see scanButtonKeyCode). This long press event can be used to add a secondary action. For example, if the primary action is to count some items with barcodes (e.g. products at goods-in), it is comes very handy if a number pad pops up on the screen when the scan button is held. Large number can then be easily typed it instead of scanning fifty times in a row. 
 Default: 100  
 Wait duration (ms) after keypress event to check if scanning is finished
 ###avgTimeByChar
@@ -40,6 +46,18 @@ Minimum length for a scanning
 ###endChar
 Default: [9,13]  
 Chars to remove and means end of scanning
+###startChar:
+Default: []
+Chars to remove and means start of scanning
+###ignoreIfFocusOn
+Default: 'input'
+Ignore scans if the currently focued element matches this selector. This is usefull to let the focused control handle the input by itself. By default, scanner detection is disabled if an input is focused when the scan occurs. The scanned string will be inserted in the input in this case.  For example, if your default action is searching in a list of products for the scanned SKU, you might also have a form to create a new product with an input field for the SKU. If the user sets focus to this field, the scanned code will just be inserted into it and not used for searchig.
+###scanButtonKeyCode
+Default: 0
+Key code of the scanner hardware button (if the scanner button a acts as a key itself). Knowing this key code is important, becaus it is not part oft the scanned code and must be ignored. On the other hand, knowing it can be usefull: pressing the button multiple times fast normally results just in one scan, but you still could count the number of times pressed, allowing the user to input quantities this way (typical use case would be counting product at goods-in). 
+###scanButtonLongPressThreshold
+Default: 3
+You can let the user perform some special action by pressing and holding the scan button. In this case the button will issue multiple keydown events. This parameter sets, how many sequential events should be interpreted as holding the button down.  
 ###stopPropagation
 Default: false  
 Stop immediate propagation on keypress event

--- a/jquery.scannerdetection.js
+++ b/jquery.scannerdetection.js
@@ -9,7 +9,7 @@
  * Project home:
  * https://github.com/julien-maurel/jQuery-Scanner-Detection
  *
- * Version: 1.1.4
+ * Version: 1.2
  *
  */
 (function($){
@@ -22,15 +22,28 @@
             });
             return this;
         }
+		
+		// If false (boolean) given, deinitialize plugin
+		if(options === false){
+			this.each(function(){
+				this.scannerDetectionOff();
+			});
+			return this;
+		}
 
         var defaults={
             onComplete:false, // Callback after detection of a successfull scanning (scanned string in parameter)
             onError:false, // Callback after detection of a unsuccessfull scanning (scanned string in parameter)
             onReceive:false, // Callback after receive a char (scanned char in parameter)
-            timeBeforeScanTest:100, // Wait duration (ms) after keypress event to check if scanning is finished
+			timeBeforeScanTest:100, // Wait duration (ms) after keypress event to check if scanning is finished
             avgTimeByChar:30, // Average time (ms) between 2 chars. Used to do difference between keyboard typing and scanning
             minLength:6, // Minimum length for a scanning
             endChar:[9,13], // Chars to remove and means end of scanning
+			startChar:[], // Chars to remove and means start of scanning
+			ignoreIfFocusOn: 'input', // do not handle scans if the currently focued element matches this selector
+			scanButtonKeyCode:0, // Key code of the scanner hardware button (if the scanner button a acts as a key itself) 
+			scanButtonLongPressThreshold:3, // How many times the hardware button should issue a pressed event before a barcode is read to detect a longpress, 
+            onScanButtonLongPressed:false, // Callback after receive a char (scanned string an number of times the key was pressed as parameters)
             stopPropagation:false, // Stop immediate propagation on keypress event
             preventDefault:false // Prevent default action on keypress event
         };
@@ -44,21 +57,47 @@
         }
         
         this.each(function(){
-            var self=this, $self=$(self), firstCharTime=0, lastCharTime=0, stringWriting='', callIsScanner=false, testTimer=false;
+            var self=this, $self=$(self), firstCharTime=0, lastCharTime=0, stringWriting='', callIsScanner=false, testTimer=false, scanButtonCounter=0;
             var initScannerDetection=function(){
                 firstCharTime=0;
                 stringWriting='';
+				scanButtonCounter=0;
             };
+			self.scannerDetectionOff=function(){
+				$self.unbind('keydown.scannerDetection');
+				$self.unbind('keypress.scannerDetection');
+			}
+			self.isFocusOnIgnoredElement=function(){
+				if (typeof options.ignoreIfFocusOn === 'string'){
+					if ($(':focus').is(options.ignoreIfFocusOn)){
+						return true;
+					} else if (typeof options.ignoreIfFocusOn === 'array'){
+						var focused = $(':focus');
+						for (var i=0; i<options.ignoreIfFocusOn.length; i++){
+							if (focused.is(options.ignoreIfFocusOn[i])){
+								return true;
+							}
+						}
+					}
+				}
+				return false;
+			}
             self.scannerDetectionTest=function(s){
-                // If string is given, test it
+                // If string is given, test it				
                 if(s){
                     firstCharTime=lastCharTime=0;
                     stringWriting=s;
                 }
+				
+				if (!scanButtonCounter){
+					scanButtonCounter = 1;
+				}
+				
                 // If all condition are good (length, time...), call the callback and re-initialize the plugin for next scanning
                 // Else, just re-initialize
                 if(stringWriting.length>=options.minLength && lastCharTime-firstCharTime<stringWriting.length*options.avgTimeByChar){
-                    if(options.onComplete) options.onComplete.call(self,stringWriting);
+					if(options.onScanButtonLongPressed && scanButtonCounter > options.scanButtonLongPressThreshold) options.onScanButtonLongPressed.call(self,stringWriting,scanButtonCounter);
+                    else if(options.onComplete) options.onComplete.call(self,stringWriting,scanButtonCounter);
                     $self.trigger('scannerDetectionComplete',{string:stringWriting});
                     initScannerDetection();
                     return true;
@@ -70,9 +109,17 @@
                 }
             }
             $self.data('scannerDetection',{options:options}).unbind('.scannerDetection').bind('keydown.scannerDetection',function(e){
-                // Add event on keydown because keypress is not triggered for non character keys (tab, up, down...)
-                // So need that to check endChar (that is often tab or enter) and call keypress if necessary
-                if(firstCharTime && options.endChar.indexOf(e.which)!==-1){
+                // If it's just the button of the scanner, ignore it and wait for the real input
+				if(options.scanButtonKeyCode && e.which==options.scanButtonKeyCode) {
+                    scanButtonCounter++;
+                    // Cancel default
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                }
+				// Add event on keydown because keypress is not triggered for non character keys (tab, up, down...)
+                // So need that to check endChar and startChar (that is often tab or enter) and call keypress if necessary
+                else if((firstCharTime && options.endChar.indexOf(e.which)!==-1) 
+				|| (!firstCharTime && options.startChar.indexOf(e.which)!==-1)){
                     // Clone event, set type and trigger it
                     var e2=jQuery.Event('keypress',e);
                     e2.type='keypress.scannerDetection';
@@ -82,6 +129,7 @@
                     e.stopImmediatePropagation();
                 }
             }).bind('keypress.scannerDetection',function(e){
+				if (this.isFocusOnIgnoredElement()) return;				
                 if(options.stopPropagation) e.stopImmediatePropagation();
                 if(options.preventDefault) e.preventDefault();
 
@@ -89,7 +137,11 @@
                     e.preventDefault();
                     e.stopImmediatePropagation();
                     callIsScanner=true;
-                }else{
+                }else if(!firstCharTime && options.startChar.indexOf(e.which)!==-1){
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+					callIsScanner=false;
+				}else{
                     stringWriting+=String.fromCharCode(e.which);
                     callIsScanner=false;
                 }

--- a/jquery.scannerdetection.js
+++ b/jquery.scannerdetection.js
@@ -42,8 +42,8 @@
 			startChar:[], // Chars to remove and means start of scanning
 			ignoreIfFocusOn: 'input', // do not handle scans if the currently focued element matches this selector
 			scanButtonKeyCode:0, // Key code of the scanner hardware button (if the scanner button a acts as a key itself) 
-			scanButtonLongPressThreshold:3, // How many times the hardware button should issue a pressed event before a barcode is read to detect a longpress, 
-            onScanButtonLongPressed:false, // Callback after receive a char (scanned string an number of times the key was pressed as parameters)
+			scanButtonLongPressThreshold:3, // How many times the hardware button should issue a pressed event before a barcode is read to detect a longpress
+            onScanButtonLongPressed:false, // Callback after detection of a successfull scan while the scan button was pressed and held down
             stopPropagation:false, // Stop immediate propagation on keypress event
             preventDefault:false // Prevent default action on keypress event
         };


### PR DESCRIPTION
- Ability to handle the scan button events of built-in scanners (like the MIO Work handhelds) including a separate callback for pressing and holding the button
- Possibility to deinitialize the plugin explicitly
- Ignoring scans if certain controls have focus
- Handling prefix characters if the scanner sends a special prefix

See changes in the readme for details.